### PR TITLE
Rename integration from 'Nature Remo Lapis' to 'Nature Remo'

### DIFF
--- a/custom_components/nature_remo/README.md
+++ b/custom_components/nature_remo/README.md
@@ -1,6 +1,6 @@
-# Nature Remo Lapis Custom Integration for Home Assistant
+# Nature Remo Custom Integration for Home Assistant
 
-This custom integration allows you to control Nature Remo Lapis devices and all connected appliances through Home Assistant.
+This custom integration allows you to control Nature Remo devices and all connected appliances through Home Assistant.
 
 ## Features
 
@@ -48,11 +48,11 @@ This custom integration allows you to control Nature Remo Lapis devices and all 
 5. Add this repository URL: `https://github.com/98kuwa036/codings`
 6. Select category: "Integration"
 7. Click "Add"
-8. Search for "Nature Remo Lapis" and install
+8. Search for "Nature Remo" and install
 
 ### Manual Installation
 
-1. Copy the `custom_components/nature_remo_lapis` directory to your Home Assistant `custom_components` directory
+1. Copy the `custom_components/nature_remo` directory to your Home Assistant `custom_components` directory
 2. Restart Home Assistant
 
 ## Configuration
@@ -68,7 +68,7 @@ This custom integration allows you to control Nature Remo Lapis devices and all 
 
 1. Go to Settings → Devices & Services
 2. Click "Add Integration"
-3. Search for "Nature Remo Lapis"
+3. Search for "Nature Remo"
 4. Enter your access token
 5. Click "Submit"
 

--- a/custom_components/nature_remo/__init__.py
+++ b/custom_components/nature_remo/__init__.py
@@ -1,4 +1,4 @@
-"""The Nature Remo Lapis integration."""
+"""The Nature Remo integration."""
 import logging
 from datetime import timedelta
 
@@ -23,7 +23,7 @@ PLATFORMS = [
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Set up Nature Remo Lapis from a config entry."""
+    """Set up Nature Remo from a config entry."""
     access_token = entry.data[CONF_ACCESS_TOKEN]
     session = async_get_clientsession(hass)
     api = NatureRemoAPI(access_token, session)

--- a/custom_components/nature_remo/api.py
+++ b/custom_components/nature_remo/api.py
@@ -1,4 +1,4 @@
-"""API client for Nature Remo Lapis."""
+"""API client for Nature Remo."""
 import logging
 from typing import Any
 

--- a/custom_components/nature_remo/climate.py
+++ b/custom_components/nature_remo/climate.py
@@ -1,4 +1,4 @@
-"""Support for Nature Remo Lapis climate devices."""
+"""Support for Nature Remo climate devices."""
 import logging
 from typing import Any
 
@@ -44,7 +44,7 @@ async def async_setup_entry(
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up Nature Remo Lapis climate from a config entry."""
+    """Set up Nature Remo climate from a config entry."""
     coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
     api = hass.data[DOMAIN][entry.entry_id]["api"]
 
@@ -103,7 +103,7 @@ class NatureRemoClimate(CoordinatorEntity, ClimateEntity):
                 "identifiers": {(DOMAIN, device_id)},
                 "name": device_name,
                 "manufacturer": "Nature",
-                "model": "Remo Lapis",
+                "model": "Nature Remo",
             }
         return None
 

--- a/custom_components/nature_remo/config_flow.py
+++ b/custom_components/nature_remo/config_flow.py
@@ -1,4 +1,4 @@
-"""Config flow for Nature Remo Lapis integration."""
+"""Config flow for Nature Remo integration."""
 import logging
 from typing import Any
 
@@ -16,8 +16,8 @@ from .const import DOMAIN, ERROR_AUTH_INVALID, ERROR_CANNOT_CONNECT, ERROR_UNKNO
 _LOGGER = logging.getLogger(__name__)
 
 
-class NatureRemoLapisConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
-    """Handle a config flow for Nature Remo Lapis."""
+class NatureRemoConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Nature Remo."""
 
     VERSION = 1
 

--- a/custom_components/nature_remo/const.py
+++ b/custom_components/nature_remo/const.py
@@ -1,6 +1,6 @@
-"""Constants for the Nature Remo Lapis integration."""
+"""Constants for the Nature Remo integration."""
 
-DOMAIN = "nature_remo_lapis"
+DOMAIN = "nature_remo"
 
 # Configuration
 CONF_ACCESS_TOKEN = "access_token"

--- a/custom_components/nature_remo/light.py
+++ b/custom_components/nature_remo/light.py
@@ -1,4 +1,4 @@
-"""Support for Nature Remo Lapis lights."""
+"""Support for Nature Remo lights."""
 import logging
 from typing import Any
 
@@ -22,7 +22,7 @@ async def async_setup_entry(
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up Nature Remo Lapis light from a config entry."""
+    """Set up Nature Remo light from a config entry."""
     coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
     api = hass.data[DOMAIN][entry.entry_id]["api"]
 
@@ -76,7 +76,7 @@ class NatureRemoLight(CoordinatorEntity, LightEntity):
                 "identifiers": {(DOMAIN, device_id)},
                 "name": device_name,
                 "manufacturer": "Nature",
-                "model": "Remo Lapis",
+                "model": "Nature Remo",
             }
         return None
 

--- a/custom_components/nature_remo/manifest.json
+++ b/custom_components/nature_remo/manifest.json
@@ -1,6 +1,6 @@
 {
-  "domain": "nature_remo_lapis",
-  "name": "Nature Remo Lapis",
+  "domain": "nature_remo",
+  "name": "Nature Remo",
   "codeowners": ["@98kuwa036"],
   "config_flow": true,
   "documentation": "https://github.com/98kuwa036/codings",
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/98kuwa036/codings/issues",
   "requirements": ["aiohttp>=3.8.0"],
-  "version": "1.0.0"
+  "version": "1.0.1"
 }

--- a/custom_components/nature_remo/remote.py
+++ b/custom_components/nature_remo/remote.py
@@ -1,4 +1,4 @@
-"""Support for Nature Remo Lapis remote controls."""
+"""Support for Nature Remo remote controls."""
 import logging
 from typing import Any, Iterable
 
@@ -18,7 +18,7 @@ async def async_setup_entry(
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up Nature Remo Lapis remote from a config entry."""
+    """Set up Nature Remo remote from a config entry."""
     coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
     api = hass.data[DOMAIN][entry.entry_id]["api"]
 
@@ -71,7 +71,7 @@ class NatureRemoRemote(CoordinatorEntity, RemoteEntity):
                 "identifiers": {(DOMAIN, device_id)},
                 "name": device_name,
                 "manufacturer": "Nature",
-                "model": "Remo Lapis",
+                "model": "Nature Remo",
             }
         return None
 

--- a/custom_components/nature_remo/sensor.py
+++ b/custom_components/nature_remo/sensor.py
@@ -1,4 +1,4 @@
-"""Support for Nature Remo Lapis sensors."""
+"""Support for Nature Remo sensors."""
 import logging
 
 from homeassistant.components.sensor import (
@@ -28,7 +28,7 @@ async def async_setup_entry(
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up Nature Remo Lapis sensor from a config entry."""
+    """Set up Nature Remo sensor from a config entry."""
     coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
 
     sensors = []
@@ -96,7 +96,7 @@ class NatureRemoSensorBase(CoordinatorEntity, SensorEntity):
             "identifiers": {(DOMAIN, self._device_id)},
             "name": self._device_name,
             "manufacturer": "Nature",
-            "model": "Remo Lapis",
+            "model": "Nature Remo",
         }
 
 

--- a/custom_components/nature_remo/strings.json
+++ b/custom_components/nature_remo/strings.json
@@ -2,7 +2,7 @@
   "config": {
     "step": {
       "user": {
-        "title": "Nature Remo Lapis",
+        "title": "Nature Remo",
         "description": "Enter your Nature Remo access token to connect your devices.",
         "data": {
           "access_token": "Access Token"

--- a/custom_components/nature_remo/switch.py
+++ b/custom_components/nature_remo/switch.py
@@ -1,4 +1,4 @@
-"""Support for Nature Remo Lapis switches."""
+"""Support for Nature Remo switches."""
 import logging
 from typing import Any
 
@@ -18,7 +18,7 @@ async def async_setup_entry(
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up Nature Remo Lapis switch from a config entry."""
+    """Set up Nature Remo switch from a config entry."""
     coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
     api = hass.data[DOMAIN][entry.entry_id]["api"]
 
@@ -81,7 +81,7 @@ class NatureRemoSwitch(CoordinatorEntity, SwitchEntity):
                 "identifiers": {(DOMAIN, device_id)},
                 "name": device_name,
                 "manufacturer": "Nature",
-                "model": "Remo Lapis",
+                "model": "Nature Remo",
             }
         return None
 

--- a/custom_components/nature_remo/translations/en.json
+++ b/custom_components/nature_remo/translations/en.json
@@ -2,7 +2,7 @@
   "config": {
     "step": {
       "user": {
-        "title": "Nature Remo Lapis",
+        "title": "Nature Remo",
         "description": "Enter your Nature Remo access token to connect your devices.",
         "data": {
           "access_token": "Access Token"

--- a/custom_components/nature_remo/translations/ja.json
+++ b/custom_components/nature_remo/translations/ja.json
@@ -2,7 +2,7 @@
   "config": {
     "step": {
       "user": {
-        "title": "Nature Remo Lapis",
+        "title": "Nature Remo",
         "description": "デバイスを接続するためにNature Remoのアクセストークンを入力してください。",
         "data": {
           "access_token": "アクセストークン"


### PR DESCRIPTION
Changes:
- Renamed directory from nature_remo_lapis to nature_remo
- Updated domain from 'nature_remo_lapis' to 'nature_remo'
- Updated integration name from 'Nature Remo Lapis' to 'Nature Remo'
- Updated all docstrings, comments, and documentation
- Changed device model from 'Remo Lapis' to 'Nature Remo'
- Updated version to 1.0.1

This makes the integration name more generic and applicable to all Nature Remo devices (Lapis, 3, mini, E, E lite, nano, etc.) rather than being specific to the Lapis model.