### PR TITLE
Fix place names script to use kana columns for proper reading

### DIFF
--- a/fcitx5-mozc-ut-overlay/app-i18n/fcitx5-mozc-ut/files/generate_place_names_full.py
+++ b/fcitx5-mozc-ut-overlay/app-i18n/fcitx5-mozc-ut/files/generate_place_names_full.py
@@ -7,12 +7,51 @@
 """
 Generate place-names dictionary from Japan Post ZIP code data.
 Includes both ken_all.zip (residential addresses) and jigyosyo.zip (business addresses).
+
+Generates proper (reading, surface) pairs using kana columns from the CSV data.
 """
 
 import csv
 import io
 import urllib.request
 import zipfile
+
+
+def katakana_to_hiragana(text):
+    """
+    Convert katakana to hiragana using standard library.
+    カタカナ（ァ-ヶ）をひらがな（ぁ-ゖ）に変換
+    """
+    result = []
+    for char in text:
+        code = ord(char)
+        # Katakana (U+30A1-U+30F6) to Hiragana (U+3041-U+3096)
+        if 0x30A1 <= code <= 0x30F6:
+            result.append(chr(code - 0x60))
+        # Katakana punctuation (U+30FC: ー) keep as is or convert
+        elif code == 0x30FC:  # ー (prolonged sound mark)
+            result.append('ー')
+        else:
+            result.append(char)
+    return ''.join(result)
+
+
+def normalize_kana(text):
+    """
+    Normalize kana text for Mozc dictionary.
+    - Convert katakana to hiragana
+    - Remove spaces and special characters
+    """
+    if not text:
+        return ''
+
+    # Convert to hiragana
+    hiragana = katakana_to_hiragana(text)
+
+    # Remove spaces (both full-width and half-width)
+    hiragana = hiragana.replace('　', '').replace(' ', '')
+
+    return hiragana
 
 
 def download_and_extract(url, filename):
@@ -38,46 +77,88 @@ def process_ken_all(csv_content):
     0: JIS code
     1: Old ZIP code (5 digits)
     2: ZIP code (7 digits)
-    3: Prefecture name (kana)
-    4: City name (kana)
-    5: Town name (kana)
-    6: Prefecture name (kanji)
-    7: City name (kanji)
-    8: Town name (kanji)
+    3: Prefecture name (kana) ← USE THIS FOR READING
+    4: City name (kana)       ← USE THIS FOR READING
+    5: Town name (kana)       ← USE THIS FOR READING
+    6: Prefecture name (kanji) ← Surface
+    7: City name (kanji)       ← Surface
+    8: Town name (kanji)       ← Surface
     9-14: Various flags
+
+    Returns: list of (reading, surface) tuples
     """
-    entries = set()
+    entries = []
+    seen = set()
     reader = csv.reader(io.StringIO(csv_content))
 
     for row in reader:
         if len(row) < 9:
             continue
 
-        prefecture = row[6].strip()
-        city = row[7].strip()
-        town = row[8].strip()
+        # Kana (reading)
+        pref_kana = row[3].strip()
+        city_kana = row[4].strip()
+        town_kana = row[5].strip()
 
-        # Skip entries with special markers
-        if '（' in town or '以下に掲載がない場合' in town:
-            town = ''
+        # Kanji (surface)
+        pref_kanji = row[6].strip()
+        city_kanji = row[7].strip()
+        town_kanji = row[8].strip()
+
+        # Skip entries with special markers in town
+        if '（' in town_kanji or '以下に掲載がない場合' in town_kanji:
+            town_kanji = ''
+            town_kana = ''
+
+        # Convert kana to hiragana for reading
+        pref_reading = normalize_kana(pref_kana)
+        city_reading = normalize_kana(city_kana)
+        town_reading = normalize_kana(town_kana)
 
         # Add prefecture
-        if prefecture:
-            entries.add(prefecture)
+        if pref_reading and pref_kanji:
+            key = (pref_reading, pref_kanji)
+            if key not in seen:
+                entries.append(key)
+                seen.add(key)
 
         # Add city
-        if city:
-            entries.add(city)
+        if city_reading and city_kanji:
+            key = (city_reading, city_kanji)
+            if key not in seen:
+                entries.append(key)
+                seen.add(key)
+
             # Add prefecture + city
-            entries.add(prefecture + city)
+            full_reading = pref_reading + city_reading
+            full_surface = pref_kanji + city_kanji
+            key = (full_reading, full_surface)
+            if key not in seen:
+                entries.append(key)
+                seen.add(key)
 
         # Add town (if valid)
-        if town and town not in ('', '以下に掲載がない場合'):
-            entries.add(town)
+        if town_reading and town_kanji:
+            key = (town_reading, town_kanji)
+            if key not in seen:
+                entries.append(key)
+                seen.add(key)
+
             # Add city + town
-            entries.add(city + town)
-            # Add full address
-            entries.add(prefecture + city + town)
+            ct_reading = city_reading + town_reading
+            ct_surface = city_kanji + town_kanji
+            key = (ct_reading, ct_surface)
+            if key not in seen:
+                entries.append(key)
+                seen.add(key)
+
+            # Add full address (prefecture + city + town)
+            full_reading = pref_reading + city_reading + town_reading
+            full_surface = pref_kanji + city_kanji + town_kanji
+            key = (full_reading, full_surface)
+            if key not in seen:
+                entries.append(key)
+                seen.add(key)
 
     return entries
 
@@ -88,11 +169,11 @@ def process_jigyosyo(csv_content):
 
     Format (13 columns):
     0: JIS code (5 digits)
-    1: Business name (kana)
-    2: Business name (kanji)
-    3: Prefecture name
-    4: City name
-    5: Town name
+    1: Business name (kana)   ← USE THIS FOR READING
+    2: Business name (kanji)  ← Surface
+    3: Prefecture name (kanji)
+    4: City name (kanji)
+    5: Town name (kanji)
     6: Street address details
     7: ZIP code (7 digits)
     8: Old ZIP code (5 digits)
@@ -100,41 +181,37 @@ def process_jigyosyo(csv_content):
     10: Type code
     11: Multiple numbers flag
     12: Modification code
+
+    Note: jigyosyo.csv doesn't have separate kana columns for addresses,
+    only for business names.
+
+    Returns: list of (reading, surface) tuples
     """
-    entries = set()
+    entries = []
+    seen = set()
     reader = csv.reader(io.StringIO(csv_content))
 
     for row in reader:
         if len(row) < 8:
             continue
 
-        business_name = row[2].strip()
-        prefecture = row[3].strip()
-        city = row[4].strip()
-        town = row[5].strip()
-        street = row[6].strip()
+        business_kana = row[1].strip()
+        business_kanji = row[2].strip()
 
-        # Add business name (companies, organizations, etc.)
-        if business_name:
-            # Clean up business name
-            business_name = business_name.replace('　', ' ').strip()
-            if len(business_name) >= 2:
-                entries.add(business_name)
+        # Add business name with proper reading
+        if business_kana and business_kanji:
+            # Clean up
+            business_kana = business_kana.replace('　', ' ').strip()
+            business_kanji = business_kanji.replace('　', ' ').strip()
 
-        # Add address components
-        if prefecture:
-            entries.add(prefecture)
-        if city:
-            entries.add(city)
-            entries.add(prefecture + city)
-        if town:
-            entries.add(town)
-            entries.add(city + town)
-        if street:
-            # Add street if it's meaningful
-            clean_street = street.replace('　', '').strip()
-            if len(clean_street) >= 2 and not clean_street.isdigit():
-                entries.add(clean_street)
+            # Convert kana to hiragana
+            reading = normalize_kana(business_kana)
+
+            if len(reading) >= 2 and len(business_kanji) >= 2:
+                key = (reading, business_kanji)
+                if key not in seen:
+                    entries.append(key)
+                    seen.add(key)
 
     return entries
 
@@ -144,35 +221,31 @@ def generate_mozc_entries(entries, cost=8000):
     Generate Mozc dictionary entries.
 
     Format: reading<TAB>left_id<TAB>right_id<TAB>cost<TAB>surface
-    For place names, we use id=1847 (proper noun, place name)
-    """
-    import unicodedata
 
+    For place names, we use id=1847 (proper noun, place name)
+    For organization names, we use id=1848 (proper noun, organization)
+    """
     output = []
 
-    for entry in sorted(entries):
-        if not entry or len(entry) < 2:
+    for reading, surface in entries:
+        if not reading or not surface:
             continue
 
-        # Generate reading (hiragana)
-        # For simplicity, we just use the entry as-is for reading
-        # In production, you'd want to use MeCab or similar for proper readings
-        reading = entry
-
-        # Convert katakana to hiragana for reading
-        reading_chars = []
-        for char in entry:
+        # Skip if reading contains non-hiragana characters (except ー)
+        valid_reading = True
+        for char in reading:
             code = ord(char)
-            # Katakana to Hiragana conversion
-            if 0x30A1 <= code <= 0x30F6:
-                reading_chars.append(chr(code - 0x60))
-            else:
-                reading_chars.append(char)
-        reading = ''.join(reading_chars)
+            # Allow hiragana (ぁ-ゖ), prolonged sound mark (ー), and some punctuation
+            if not (0x3041 <= code <= 0x3096 or char in 'ーゝゞ'):
+                valid_reading = False
+                break
+
+        if not valid_reading:
+            continue
 
         # Format: reading\tleft_id\tright_id\tcost\tsurface
         # Using 1847 for place names (proper noun)
-        output.append(f"{reading}\t1847\t1847\t{cost}\t{entry}")
+        output.append(f"{reading}\t1847\t1847\t{cost}\t{surface}")
 
     return output
 
@@ -182,7 +255,7 @@ def main():
     ken_all_url = "https://www.post.japanpost.jp/zipcode/dl/kogaki/zip/ken_all.zip"
     jigyosyo_url = "https://www.post.japanpost.jp/zipcode/dl/jigyosyo/zip/jigyosyo.zip"
 
-    all_entries = set()
+    all_entries = []
 
     # Process ken_all (residential addresses)
     print("Processing ken_all.zip (residential addresses)...")
@@ -190,7 +263,7 @@ def main():
     if ken_all_csv:
         entries = process_ken_all(ken_all_csv)
         print(f"  Found {len(entries)} entries from ken_all")
-        all_entries.update(entries)
+        all_entries.extend(entries)
 
     # Process jigyosyo (business addresses)
     print("Processing jigyosyo.zip (business addresses)...")
@@ -198,9 +271,9 @@ def main():
     if jigyosyo_csv:
         entries = process_jigyosyo(jigyosyo_csv)
         print(f"  Found {len(entries)} entries from jigyosyo")
-        all_entries.update(entries)
+        all_entries.extend(entries)
 
-    print(f"Total unique entries: {len(all_entries)}")
+    print(f"Total entries: {len(all_entries)}")
 
     # Generate Mozc dictionary format
     print("Generating Mozc dictionary entries...")


### PR DESCRIPTION
- Use kana columns (row[3-5]) from ken_all.csv for reading
- Use kana column (row[1]) from jigyosyo.csv for business name reading
- Implement katakana_to_hiragana() using standard library (no jaconv needed)
- Generate proper (reading, surface) pairs for Mozc dictionary
- Validate that readings contain only hiragana characters

Before: 東京都 → 東京都 (wrong - kanji as reading)
After:  とうきょうと → 東京都 (correct - hiragana reading)