### PR TITLE
Fix place names script to use kana columns for proper reading

### DIFF
--- a/fcitx5-mozc-ut-overlay/app-i18n/fcitx5-mozc-ut/fcitx5-mozc-ut-2.32.5994.102.ebuild
+++ b/fcitx5-mozc-ut-overlay/app-i18n/fcitx5-mozc-ut/fcitx5-mozc-ut-2.32.5994.102.ebuild
@@ -121,9 +121,23 @@ _generate_place_names() {
 	curl -L -o jigyosyo.zip "${jigyosyo_url}" || die "Failed to download jigyosyo.zip"
 	unzip -o jigyosyo.zip || die "Failed to extract jigyosyo.zip"
 
+	# Find the actual CSV filenames (may be uppercase or lowercase)
+	local ken_all_csv=$(find . -maxdepth 1 -iname 'ken_all.csv' -print -quit)
+	local jigyosyo_csv=$(find . -maxdepth 1 -iname 'jigyosyo.csv' -print -quit)
+
+	if [[ -z "${ken_all_csv}" ]]; then
+		die "ken_all.csv not found after extraction"
+	fi
+	if [[ -z "${jigyosyo_csv}" ]]; then
+		die "jigyosyo.csv not found after extraction"
+	fi
+
+	einfo "  Found: ${ken_all_csv}, ${jigyosyo_csv}"
+
 	# Use our custom script to generate dictionary with both sources
 	cp "${FILESDIR}/generate_place_names_full.py" . || die
-	"${EPYTHON}" generate_place_names_full.py || die "Failed to generate place-names dictionary"
+	"${EPYTHON}" generate_place_names_full.py "${ken_all_csv}" "${jigyosyo_csv}" \
+		|| die "Failed to generate place-names dictionary"
 
 	# Return the generated file path
 	echo "${workdir}/place-names/mozcdic-ut-place-names.txt"


### PR DESCRIPTION
Major fixes based on Gemini review:

Python script changes:
- Remove download functionality (ebuild already downloads)
- Accept CSV filenames as command-line arguments
- Use unicodedata.normalize('NFKC') for half-width kana support
- Properly read kana columns for reading (row[3-5] for ken_all)
- Convert katakana to hiragana for Mozc dictionary format

Ebuild changes:
- Find CSV files with case-insensitive search (KEN_ALL.CSV or ken_all.csv)
- Pass CSV filenames as arguments to Python script
- Add validation to ensure CSV files exist

This fixes the critical bug where kanji was used as reading instead of proper hiragana conversion from the kana columns.

Before: 東京都 → 東京都 (wrong)
After:  とうきょうと → 東京都 (correct)